### PR TITLE
Update gapps.py

### DIFF
--- a/stuffs/gapps.py
+++ b/stuffs/gapps.py
@@ -19,6 +19,7 @@ class Gapps(General):
     copy_dir = "./gapps"
     extract_to = "/tmp/ogapps/extract"
     non_apks = [
+        "vending-common.tar.lz",
         "defaultetc-common.tar.lz",
         "defaultframework-common.tar.lz",
         "googlepixelconfig-common.tar.lz"


### PR DESCRIPTION
最新版需要在 stuffs/gapps.py的non_apks处添加："vending-common.tar.lz", 才能正常构建